### PR TITLE
SWELL: fix build with WDL_NO_DEFINE_MINMAX defined

### DIFF
--- a/WDL/swell/swell-wnd.mm
+++ b/WDL/swell/swell-wnd.mm
@@ -251,7 +251,7 @@ STANDARD_CONTROL_NEEDSDISPLAY_IMPL
   if (status)
   {
 //    [controlView lockFocus];
-    int w=min(cellFrame.size.width, cellFrame.size.height);
+    int w=wdl_min(cellFrame.size.width, cellFrame.size.height);
     [status drawInRect:NSMakeRect(cellFrame.origin.x,cellFrame.origin.y,w,cellFrame.size.height) fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
  //   [controlView unlockFocus];
   }


### PR DESCRIPTION
Building with WDL_NO_DEFINE_MINMAX defined on OSX is broken since ce641d4f5b0de0b20daf254998b55a0ec1a20c93 because it tries to use the `min` macro which is undeclared.

This commit fixes this by using `wdl_min` instead.

Using WDL_NO_DEFINE_MINMAX prevents "macro min is incompatible with C++" warnings when  including (directly or indirectly) `<limits>` from Apple's standard library.
