### PR TITLE
Linux UX Improvements

### DIFF
--- a/WDL/swell/swell-internal.h
+++ b/WDL/swell/swell-internal.h
@@ -1227,7 +1227,8 @@ static void __listview_mergesort_internal(void *base, size_t nmemb, size_t size,
   fd(menu_text_sel, RGB(224,224,224), menu_bg) \
   f(menu_scroll, RGB(64,64,64)) \
   fd(menu_scroll_arrow, RGB(96,96,96), _3dshadow) \
-  fd(menu_submenu_arrow, RGB(96,96,96), _3dshadow) \
+  fd(menu_submenu_arrow, RGB(96,96,96), menu_text) \
+  fd(menu_submenu_arrow_sel, RGB(96,96,96), menu_bg) \
   fd(menubar_bg, RGB(192,192,192), menu_bg) \
   fd(menubar_text, RGB(0,0,0), menu_text) \
   fd(menubar_text_disabled, RGB(224,224,224), menu_text_disabled) \

--- a/WDL/swell/swell-internal.h
+++ b/WDL/swell/swell-internal.h
@@ -1253,6 +1253,8 @@ static void __listview_mergesort_internal(void *base, size_t nmemb, size_t size,
   fd(listview_text_sel, RGB(0,0,0), listview_text) \
   fd(listview_grid, RGB(224,224,224), _3dhilight) \
   f(listview_hdr_arrow,RGB(96,96,96)) \
+  fd(listview_shadow, RGB(96,96,96), _3dshadow) \
+  fd(listview_hilight, RGB(224,224,224), _3dhilight) \
   fd(listview_hdr_shadow, RGB(96,96,96), _3dshadow) \
   fd(listview_hdr_hilight, RGB(224,224,224), _3dhilight) \
   fd(listview_hdr_bg, RGB(192,192,192), _3dface) \
@@ -1262,6 +1264,8 @@ static void __listview_mergesort_internal(void *base, size_t nmemb, size_t size,
   f(treeview_bg_sel, RGB(128,128,255)) \
   f(treeview_text_sel, RGB(0,0,0)) \
   f(treeview_arrow, RGB(96,96,96)) \
+  fd(treeview_shadow, RGB(96,96,96), _3dshadow) \
+  fd(treeview_hilight, RGB(224,224,224), _3dhilight) \
   fd(tab_shadow, RGB(96,96,96), _3dshadow) \
   fd(tab_hilight, RGB(224,224,224), _3dhilight) \
   fd(tab_text, RGB(0,0,0), button_text) \
@@ -1270,8 +1274,8 @@ static void __listview_mergesort_internal(void *base, size_t nmemb, size_t size,
   fd(group_shadow, RGB(96,96,96), _3dshadow) \
   fd(group_hilight, RGB(224,224,224), _3dhilight) \
   f(focus_hilight, RGB(140,190,233)) \
-
   
+
 
 struct swell_colortheme {
 #define __def_theme_ent(x,c) int x;

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -529,12 +529,13 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
         {
           RECT cr;
           GetClientRect(hwnd,&cr);
-          HBRUSH br=CreateSolidBrush(g_swell_ctheme.menu_bg);
+          HBRUSH br = CreateSolidBrush(g_swell_ctheme.menu_bg);
           HBRUSH br2 = CreateSolidBrushAlpha(g_swell_ctheme.menu_scroll,0.5f);
           HBRUSH br3 = CreateSolidBrush(g_swell_ctheme.menu_scroll_arrow);
           HBRUSH br_submenu_arrow = CreateSolidBrush(g_swell_ctheme.menu_submenu_arrow);
-          HPEN pen=CreatePen(PS_SOLID,0,g_swell_ctheme.menu_shadow);
-          HPEN pen2=CreatePen(PS_SOLID,0,g_swell_ctheme.menu_hilight);
+          HBRUSH br_submenu_arrow_sel = CreateSolidBrush(g_swell_ctheme.menu_submenu_arrow_sel);
+          HPEN pen = CreatePen(PS_SOLID,0,g_swell_ctheme.menu_shadow);
+          HPEN pen2 = CreatePen(PS_SOLID,0,g_swell_ctheme.menu_hilight);
           HGDIOBJ oldbr = SelectObject(ps.hdc,br);
           HGDIOBJ oldpen = SelectObject(ps.hdc,pen2);
           Rectangle(ps.hdc,cr.left,cr.top,cr.right,cr.bottom);
@@ -587,6 +588,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
             {
               HBRUSH brs=CreateSolidBrush(g_swell_ctheme.menu_bg_sel);
               RECT r2=r;
+              r2.left = cr.left;
               FillRect(ps.hdc,&r2,brs);
               DeleteObject(brs);
               SetTextColor(ps.hdc,g_swell_ctheme.menu_text_sel);
@@ -657,14 +659,26 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
                  {xp + sz,yp}
                };
                HGDIOBJ oldPen = SelectObject(ps.hdc,GetStockObject(NULL_PEN));
-               SelectObject(ps.hdc,br_submenu_arrow);
+               
+               if (x == menu->sel_vis && !dis)
+                 SelectObject(ps.hdc,br_submenu_arrow_sel);
+               else
+                 SelectObject(ps.hdc,br_submenu_arrow);
+
                Polygon(ps.hdc,pts,3);
 
                SelectObject(ps.hdc,oldPen);
+
+
             }
             if (inf->fState&MF_CHECKED)
             {
-              const int col = dis ? g_swell_ctheme.menu_text_disabled : g_swell_ctheme.menu_text;
+              int col;
+              if (x == menu->sel_vis && !dis)
+                col = g_swell_ctheme.menu_text_sel;
+              else
+                col = dis ? g_swell_ctheme.menu_text_disabled : g_swell_ctheme.menu_text;
+
               HPEN tpen = CreatePen(PS_SOLID,0, col);
               HBRUSH tbr = CreateSolidBrush(col);
               HGDIOBJ oldBrush = SelectObject(ps.hdc,tbr);

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -1079,7 +1079,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
 
             RECT r;
             GetClientRect(hwnd,&r);
-            m_trackingPt.x=r.right - SWELL_UI_SCALE(3);
+            m_trackingPt.x=r.right;
             m_trackingPt.y=item_ypos;
             m_trackingPt2.x=r.left + lcol/4;
             m_trackingPt2.y=item_ypos;

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -409,7 +409,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
   static int lcol, rcol, mcol, top_margin, separator_ht, text_ht_pad, bitmap_ht_pad, scroll_margin, item_bm_pad;
   if (!lcol)
   {
-    lcol=SWELL_UI_SCALE(24); rcol=SWELL_UI_SCALE(12); mcol=SWELL_UI_SCALE(10);
+    lcol=SWELL_UI_SCALE(30); rcol=SWELL_UI_SCALE(18); mcol=SWELL_UI_SCALE(10);
     top_margin=SWELL_UI_SCALE(4); separator_ht=SWELL_UI_SCALE(8); 
     text_ht_pad=SWELL_UI_SCALE(4); bitmap_ht_pad=SWELL_UI_SCALE(4);
     scroll_margin=SWELL_UI_SCALE(10);
@@ -637,13 +637,14 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
             else 
             {
               SelectObject(ps.hdc,pen2);
-              int y = r.top/2+r.bottom/2, right = r.right-rcol*3/2;
-              MoveToEx(ps.hdc,r.left,y,NULL);
+              int margin = rcol / 2;
+              int y = r.top/2+r.bottom/2, left = cr.left+margin, right = r.right-margin;
+              MoveToEx(ps.hdc,left,y,NULL);
               LineTo(ps.hdc,right,y);
               SelectObject(ps.hdc,pen);
 
               y++;
-              MoveToEx(ps.hdc,r.left,y,NULL);
+              MoveToEx(ps.hdc,left,y,NULL);
               LineTo(ps.hdc,right,y);
             }
             if (inf->hSubMenu) 
@@ -682,8 +683,8 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
                   POINT pts[4];
                   for (int i=0;i<4; i ++)
                   {
-                    pts[i].x = xo + ((int)coords[i*2+pass*4] * sz + 63) / 128;
-                    pts[i].y = yo + ((int)coords[i*2+pass*4+1] * sz + 63) / 128;
+                    pts[i].x = lcol/2 + sz * ((int)coords[i*2+pass*4] - 64) / 128;
+                    pts[i].y = (r.bottom+r.top)/2 + sz * ((int)coords[i*2+pass*4+1] - 64) / 128;
                   }
                   Polygon(ps.hdc,pts,4);
                 }

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -1081,7 +1081,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
             GetClientRect(hwnd,&r);
             m_trackingPt.x=r.right;
             m_trackingPt.y=item_ypos;
-            m_trackingPt2.x=r.left + lcol/4;
+            m_trackingPt2.x=r.left;
             m_trackingPt2.y=item_ypos;
             ClientToScreen(hwnd,&m_trackingPt);
             ClientToScreen(hwnd,&m_trackingPt2);

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -649,7 +649,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
             }
             if (inf->hSubMenu) 
             {
-               const int sz = (r.bottom-r.top)/4, xp = r.right - sz*2, yp = (r.top + r.bottom)/2;
+               const int sz = (r.bottom-r.top)/5, xp = r.right - rcol/2 - sz, yp = (r.top + r.bottom)/2;
 
                POINT pts[3] = {
                  {xp, yp-sz},

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -669,7 +669,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
               HBRUSH tbr = CreateSolidBrush(col);
               HGDIOBJ oldBrush = SelectObject(ps.hdc,tbr);
               HGDIOBJ oldPen = SelectObject(ps.hdc,tpen);
-              const int sz = (wdl_min(lcol, r.bottom-r.top) - SWELL_UI_SCALE(6));
+              const int sz = (wdl_min(lcol, r.bottom-r.top) - SWELL_UI_SCALE(10));
               const int xo = SWELL_UI_SCALE(4), yo = (r.bottom+r.top)/2 - sz/2;
               if (inf->fType&MFT_RADIOCHECK)
               {
@@ -677,7 +677,7 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
               }
               else
               {
-                static const unsigned char coords[12] = { 128, 30, 108, 11, 48, 72, 48, 112, 0, 65, 20, 46, };
+                static const unsigned char coords[12] = { 0, 76, 12, 64, 40, 92, 40, 118, 116, 16, 128, 28, };
                 for (int pass=0;pass<2;pass++)
                 {
                   POINT pts[4];

--- a/WDL/swell/swell-menu-generic.cpp
+++ b/WDL/swell/swell-menu-generic.cpp
@@ -543,12 +543,6 @@ static LRESULT WINAPI submenuWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
           int x;
           int ypos = top_margin;
 
-          MoveToEx(ps.hdc,cr.left+lcol-SWELL_UI_SCALE(4),cr.top,NULL);
-          LineTo(ps.hdc,cr.left+lcol-SWELL_UI_SCALE(4),cr.bottom);
-          SelectObject(ps.hdc,pen);
-          MoveToEx(ps.hdc,cr.left+lcol-SWELL_UI_SCALE(5),cr.top,NULL);
-          LineTo(ps.hdc,cr.left+lcol-SWELL_UI_SCALE(5),cr.bottom);
-
           hwnd->m_extra[1]=0;
           for (x=wdl_max(hwnd->m_extra[0],0); x < (menu->items.GetSize()); x++)
           {

--- a/WDL/swell/swell-wnd-generic.cpp
+++ b/WDL/swell/swell-wnd-generic.cpp
@@ -4659,6 +4659,7 @@ forceMouseMove:
         {
           RECT cr; 
           GetClientRect(hwnd,&cr); 
+          RECT rr = cr;
           HBRUSH bgbr = CreateSolidBrush(lvs->m_color_bg);
           FillRect(ps.hdc,&cr,bgbr);
           DeleteObject(bgbr);
@@ -4967,6 +4968,9 @@ forceMouseMove:
                   totalw,lvs->m_scroll_x);
             }
           }
+          Draw3DBox(ps.hdc,&rr,-1,
+            g_swell_ctheme.listview_hilight,
+            g_swell_ctheme.listview_shadow);
           DeleteObject(bgbr);
 
           EndPaint(hwnd,&ps);
@@ -5656,6 +5660,9 @@ forceMouseMove:
             DeleteObject(br);
 
             drawVerticalScrollbar(ps.hdc,cr,total_h,tvs->m_scroll_y);
+            Draw3DBox(ps.hdc,&cr,-1,
+              g_swell_ctheme.treeview_hilight,
+              g_swell_ctheme.treeview_shadow);
           }
 
           EndPaint(hwnd,&ps);

--- a/WDL/swell/swell-wnd-generic.cpp
+++ b/WDL/swell/swell-wnd-generic.cpp
@@ -7009,7 +7009,7 @@ static int menuBarHitTest(HWND hwnd, int mousex, int mousey, RECT *rOut, int for
   {
     HDC dc = GetWindowDC(hwnd);
 
-    int x,xpos=r.left + g_swell_ctheme.menubar_margin_width;
+    int x,xpos=r.left;
     HMENU__ *menu = (HMENU__*)hwnd->m_menu;
     HGDIOBJ oldfont = dc ? SelectObject(dc,menubar_font) : NULL;
     const int n=menu->items.GetSize();
@@ -7206,8 +7206,12 @@ LRESULT DefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
               cr.bottom = r.bottom;
               if (!dis && menu->sel_vis == x)
               {
+                RECT crb = {0};
+                crb.left = cr.left, crb.right=cr.right, crb.top=cr.top, crb.bottom=cr.bottom;
+                crb.left = crb.left - g_swell_ctheme.menubar_margin_width;
+                crb.right = crb.right + g_swell_ctheme.menubar_margin_width;
                 HBRUSH br = CreateSolidBrush(g_swell_ctheme.menubar_bg_sel);
-                FillRect(dc,&cr,br);
+                FillRect(dc,&crb,br);
                 DeleteObject(br);
                 SetTextColor(dc,g_swell_ctheme.menubar_text_sel);
               }


### PR DESCRIPTION
The goal of this pull request is to make various user interface elements look more modern on linux platforms.

### Menubar / Submenus before:

![reaper-ux-before](https://user-images.githubusercontent.com/31393177/117165036-70f1f600-adc5-11eb-9c0b-330d0a9d9d47.png)

### Menubar / Submenus before:

![reaper-ux-after](https://user-images.githubusercontent.com/31393177/117165134-849d5c80-adc5-11eb-9482-51b55a91ee37.png)

Aside from the changes that can be seen in the comparison screenshots, a border has been added to treeviews and listviews.

### Summary of new `libswell.colortheme` properties

- listview_hilight
- listview_shadow
- treeview_hilight
- treeview_shadow
- menu_submenu_arrow_sel





