### PR TITLE
Include <string.h> in heapbuf.h

### DIFF
--- a/WDL/heapbuf.h
+++ b/WDL/heapbuf.h
@@ -42,6 +42,7 @@
 #define WDL_HEAPBUF_TRACEPARM(x)
 #endif
 
+#include <string.h>
 #include "wdltypes.h"
 
 class WDL_HeapBuf


### PR DESCRIPTION
memcpy is used in the implementation of WDL_HeapBuf. According to [1],
memcpy is declared in <string.h> which is not included in WDL's
heapbuf.h, causing compilation issues on some platforms.
This patch adds the missing include directive.

[1]: https://en.cppreference.com/w/c/string/byte/memcpy