### PR TITLE
include stddef in wdltypes.h

### DIFF
--- a/WDL/wdltypes.h
+++ b/WDL/wdltypes.h
@@ -40,6 +40,7 @@ typedef unsigned long long WDL_UINT64;
 #include <windows.h>
 #include <stdio.h>
 #else
+#include <stddef.h>
 #include <stdint.h>
 typedef intptr_t INT_PTR;
 typedef uintptr_t UINT_PTR;


### PR DESCRIPTION
problem:
gcc complains about not knowing `NULL` and `size_t` in wdlutf8.h.

fix:
include stddef.h in wdltypes.h