### PR TITLE
swell-linux: ensure LD lazily binds symbols

### DIFF
--- a/WDL/swell/Makefile
+++ b/WDL/swell/Makefile
@@ -140,6 +140,9 @@ ifndef NOGDK
     endif
   endif
   LINKEXTRA += -lGL
+  ifdef PRELOAD_GDK
+    CFLAGS += -Wl,-z,lazy
+  endif
 endif
 
 CXXFLAGS = $(CFLAGS)


### PR DESCRIPTION
On newer toolchains that by default set `-Wl,-z,now`, such as Gentoo's 23.0 toolchain, setting PRELOAD_GDK causes swell's dlopen() to fail with an error like:

    Error loading '/opt/REAPER/libSwell.so': /opt/REAPER/libSwell.so: undefined symbol: gdk_x11_window_get_xid

This is because -z,now, according to the man page, "When generating an executable or shared library, mark it to tell the dynamic linker to resolve all symbols when the program is started, or when the shared library is loaded by dlopen, instead of deferring function call resolution to the point when the function is first called." This is basically the opposite of what swell's preloading feature wants.

This can be overridden by setting -z,lazy, which according to the man page, "When generating an executable or shared library, mark it to tell the dynamic linker to defer function call resolution to the point when the function is called (lazy binding), rather than at load time."

So pass -Wl,-z,lazy in the preloading case, so that it works no matter what the toolchain defaults are.