### PR TITLE
Don't hardcode the xdg-open location

### DIFF
--- a/WDL/swell/swell-wnd-generic.cpp
+++ b/WDL/swell/swell-wnd-generic.cpp
@@ -8400,7 +8400,7 @@ BOOL SWELL_IsStaticText(HWND hwnd)
 
 BOOL ShellExecute(HWND hwndDlg, const char *action,  const char *content1, const char *content2, const char *content3, int blah)
 {
-  const char *xdg = "/usr/bin/xdg-open";
+  const char *xdg = "xdg-open";
   const char *argv[3] = { NULL };
   char *tmp=NULL;
 
@@ -8450,8 +8450,8 @@ BOOL ShellExecute(HWND hwndDlg, const char *action,  const char *content1, const
   if (pid == 0) 
   {
     for (int x=0;argv[x];x++) argv[x] = strdup(argv[x]);
-    execv(argv[0],(char *const*)argv);
-    exit(0); // if execv fails for some reason
+    execvp(argv[0],(char *const*)argv);
+    exit(0); // if execvp fails for some reason
   }
   free(tmp);
   return pid>0;


### PR DESCRIPTION
When running reaper through nixpkgs, or others with different directory layout, the location of xdg-open may not be in `/usr/bin`. Rely on the environment instead of hardcoding this path.
Patch from @cfillion at https://forum.cockos.com/showthread.php?p=2808822
Confirmed working at https://github.com/NixOS/nixpkgs/issues/341752#issuecomment-2351329852