### PR TITLE
Fix eel2 regNN*regNN optimizer bug

### DIFF
--- a/WDL/eel2/nseel-compiler.c
+++ b/WDL/eel2/nseel-compiler.c
@@ -980,7 +980,6 @@ opcodeRec *nseel_resolve_named_symbol(compileContext *ctx, opcodeRec *rec, int p
     if (a) 
     {
       rec->parms.dv.valuePtr = a;
-      sname[0]=0; // for dump_ops compat really, but this shouldn't be needed anyway
     }
     return rec;
   }
@@ -2458,7 +2457,8 @@ start_over: // when an opcode changed substantially in optimization, goto here t
                   if (first_parm->namespaceidx != second_parm->namespaceidx) break;
                   WDL_FALLTHROUGH; // fall through
                 case OPCODETYPE_VARPTR:
-                  if (first_parm->relname && second_parm->relname && !stricmp(second_parm->relname,first_parm->relname)) second_parm=NULL;
+                  if (first_parm->parms.dv.valuePtr && first_parm->parms.dv.valuePtr==second_parm->parms.dv.valuePtr) second_parm=NULL;
+                  else if (first_parm->relname && second_parm->relname && first_parm->relname[0] && !stricmp(second_parm->relname,first_parm->relname)) second_parm=NULL;
                 break;
                 case OPCODETYPE_VARPTRPTR:
                   if (first_parm->parms.dv.valuePtr && first_parm->parms.dv.valuePtr==second_parm->parms.dv.valuePtr) second_parm=NULL;


### PR DESCRIPTION
## Summary

- **Bug**: `nseel_resolve_named_symbol` clears `sname[0]=0` for `regNN` variables (line 983), which causes the `x*x → sqr(x)` optimizer to treat ALL `regNN` variables as identical (comparing empty strings). `reg10*reg20` gets compiled as `sqr(reg10)`.
- **Fix 1**: Remove `sname[0]=0` — the comment already says "this shouldn't be needed anyway"
- **Fix 2**: Add `valuePtr` comparison as primary check in the `VARPTR` case of the sqr() optimization, consistent with the existing `VARPTRPTR` case. Guard the string fallback with `relname[0]` check.

## Reproduction

Any EEL script multiplying two different `regNN` variables produces incorrect results:

```
reg10 = 3;
reg20 = 5;
result = reg10 * reg20;  // Expected: 15, Got: 9 (sqr(reg10))
```

Discovered in MilkDrop/Milkwave preset rendering where rotation matrices using different regNN variables produced incorrect visual output.

## Changes

`WDL/eel2/nseel-compiler.c` — 2 insertions, 2 deletions:

1. Line 983: Remove `sname[0]=0` that cleared the variable name after resolving regNN globals
2. Lines 2460-2461: Add `valuePtr` pointer comparison (like VARPTRPTR case), guard string comparison with `relname[0]` check