### PR TITLE
Fix missing <stdlib.h> include for malloc in wdlutf8.h

### DIFF
--- a/WDL/wdlutf8.h
+++ b/WDL/wdlutf8.h
@@ -26,6 +26,7 @@ misrepresented as being the original software.
 /* todo: handle overlongs differently? */
 
 #include "wdltypes.h"
+#include <stdlib.h>
 
 #ifndef WDL_WCHAR
   #ifdef _WIN32


### PR DESCRIPTION
This adds a missing `<stdlib.h>` include in `wdlutf8.h`.

The file uses `malloc`, which causes a compilation error with C99+ compilers due to implicit function declaration:

>  error: call to undeclared library function 'malloc' with type 'void *(unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

Here is an example of the issue: [CSICode](https://github.com/benvenutti/CSICode) depends on WDL, and when building it with newer compilers (in this case MacOs arm)  we get this error https://github.com/benvenutti/CSICode/actions/runs/25453382385/job/74676279990.

This change fixes the issue and improves portability.
